### PR TITLE
apply error rate to network.connection

### DIFF
--- a/dht/dht.py
+++ b/dht/dht.py
@@ -224,7 +224,7 @@ class DHTNetwork:
     def __init__(self, networkID: int, errorRate: int):
         """ class initializer, it allows to define the networkID and the delays between nodes """
         self.networkID = networkID
-        self.errorRate = errorRate / 100.0 # get the error rate in a float [0, 1] to be comparable with random.random
+        self.errorRate = errorRate
         self.nodeStore = NodeStore()
         self.errorTracker = [] # every time that an error is tracked, add it to the queue
         self.connectionTracker = [] # every time that a connection was stablished
@@ -240,8 +240,7 @@ class DHTNetwork:
         self.connectionCnt += 1
         try:
             # check the error rate (avoid stablishing the connection if there is an error)
-            errorGuess = random.random()
-            if errorGuess < self.errorRate:
+            if random.randint(0, 99) < self.errorRate:
                 raise ConnectionError(targetNode, "simulated error", time.time())
             node = self.nodeStore.get_node(targetNode)
             self.connectionTracker.append({

--- a/dht/dht.py
+++ b/dht/dht.py
@@ -27,12 +27,12 @@ class DHTClient:
         # DHT parameters
         self.alpha = a # the concurrency parameter per path
         self.beta = b # the number of peers closest to a target that must have responded for a query path to terminate
-        self.lookupStuckMaxCnt = stuckMaxCnt # Number of maximum hops the client will do without reaching a closest peer 
+        self.lookupStuckMaxCnt = stuckMaxCnt # Number of maximum hops the client will do without reaching a closest peer
         # to finalize the lookup process
 
     def bootstrap(self) -> str:
         """ Initialize the RoutingTable from the given network and return the count of nodes per kbucket""" 
-        rtNodes = self.network.bootstrap_node(self.ID, self.k, accuracy=100)
+        rtNodes = self.network.bootstrap_node(self.ID, self.k)
         for node in rtNodes:
             self.rt.new_discovered_peer(node)
         # Return the summary of the RoutingTable
@@ -67,13 +67,13 @@ class DHTClient:
             return False
 
         def not_tracked(total, newones):
-            newNodes = {} 
+            newNodes = {}
             for node, dist in newones.items():
                 if node not in total:
                     newNodes[node] = dist
             return newNodes
         
-        while (stuckCnt < self.lookupStuckMaxCnt) and (len(nodesToTry) > 0) : 
+        while (stuckCnt < self.lookupStuckMaxCnt) and (len(nodesToTry) > 0) :
             # ask queued nodes to try
             for node in list(nodesToTry):
                 lookupSummary['connectionAttempts'] += 1

--- a/tests/test_dht.py
+++ b/tests/test_dht.py
@@ -123,7 +123,7 @@ def generateNetwork(k, size, id, errorRate):
     nodeIDs = range(1, size+1, 1)
     nodes = []
     for i in nodeIDs:
-        n = DHTClient(id=i, network=network, kbucketSize=k, a=2, b=k, stuckMaxCnt=5)
+        n = DHTClient(nodeid=i, network=network, kbucketSize=k, a=2, b=k, stuckMaxCnt=5)
         network.add_new_node(n)
         nodes.append(n)
     return network, nodes

--- a/tests/test_dht.py
+++ b/tests/test_dht.py
@@ -9,18 +9,12 @@ class TestNetwork(unittest.TestCase):
 
     def test_network(self):
         # configuration of the DHTnetwork
-        """ 
-        # TODO: add all the delay part
-        # configuration of the delays
-        delayRange = range()
-        randomSeed = ""
-        random.seed(randomSeed)
-        """ 
         k = 20
         size = 200
         id = 0
-        errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
-        network, _ = generateNetwork(k, size, id, errorRate)
+        errorRate = 0  # apply an error rate of 0 (to check if the logic pases)
+        delayRange = None  # ms
+        network, _ = generateNetwork(k, size, id, errorRate, delayRange)
         
         # check total size of the network
         totalnodes = network.nodeStore.len()
@@ -30,11 +24,11 @@ class TestNetwork(unittest.TestCase):
         for nodeID in range(k):
             # the test should actually fail if a Exception is raised
             to = random.sample(range(size-1), 1)
-            _ = network.connect_to_node(nodeID, to[0])
+            _, _ = network.connect_to_node(nodeID, to[0])
             
         # force the failure of the connections attempting to connect a peer that doesn't exist
         with self.assertRaises(ConnectionError):
-            _ = network.connect_to_node(1, size+1)
+            _, _ = network.connect_to_node(1, size+1)
 
         # check the summary of the network
         summary = network.summary()
@@ -48,7 +42,8 @@ class TestNetwork(unittest.TestCase):
         k = 2
         size = 20
         errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
-        network, nodes = generateNetwork(k, size, 0, errorRate)
+        delayRange = None  # ms
+        network, nodes = generateNetwork(k, size, 0, errorRate, delayRange)
 
         for node in nodes:
             summary = node.bootstrap()
@@ -64,7 +59,8 @@ class TestNetwork(unittest.TestCase):
         size = 500 
         id = 0
         errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
-        _, nodes = generateNetwork(k, size, id, errorRate)
+        delayRange = None  # ms
+        _, nodes = generateNetwork(k, size, id, errorRate, delayRange)
         for node in nodes:
             node.bootstrap()
    
@@ -75,7 +71,7 @@ class TestNetwork(unittest.TestCase):
         rNode = nodes[randomNodeID]
         self.assertNotEqual(rNode.network.len(), 0)
         
-        closestNodes, val, summary = rNode.lookup_for_hash(key=segH)
+        closestNodes, val, summary, _ = rNode.lookup_for_hash(key=segH)
         self.assertEqual(val, "") # empty val, nothing stored yet
         self.assertEqual(len(closestNodes), k)
         # print(f"lookup operation with {size} nodes done in {summary['finishTime'] - summary['startTime']}")
@@ -97,7 +93,8 @@ class TestNetwork(unittest.TestCase):
         size = 2
         id = 0
         errorrate = 50   # apply an error rate of 0 (to check if the logic pases)
-        network, nodes = generateNetwork(k, size, id, errorrate)
+        delayRange = None  # ms
+        network, nodes = generateNetwork(k, size, id, errorrate, delayRange)
         for node in nodes:
             node.bootstrap()
 
@@ -107,7 +104,7 @@ class TestNetwork(unittest.TestCase):
         variance = 5  # %
         for i in range(iterations):
             try:
-                _ = network.connect_to_node(nodes[0].ID, nodes[1].ID)
+                _, _ = network.connect_to_node(nodes[0].ID, nodes[1].ID)
                 successcnt += 1
             except ConnectionError as e:
                 failedcnt += 1
@@ -123,7 +120,8 @@ class TestNetwork(unittest.TestCase):
         size = 500 
         id = 0
         errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
-        _, nodes = generateNetwork(k, size, id, errorRate)
+        delayRange = None  # ms
+        _, nodes = generateNetwork(k, size, id, errorRate, delayRange)
         for node in nodes:
             node.bootstrap()
    
@@ -134,21 +132,64 @@ class TestNetwork(unittest.TestCase):
         pNode = nodes[publisherNodeID]
         self.assertNotEqual(pNode.network.len(), 0)
         
-        provideSummary = pNode.provide_block_segment(randomSegment)
+        provideSummary, _ = pNode.provide_block_segment(randomSegment)
         self.assertEqual(len(provideSummary["closestNodes"]), k)
         # print(f"provide operation with {size} nodes done in {provideSummary['finishTime'] - provideSummary['startTime']}")
         
         interestedNodeID = random.sample(range(1, size), 1)[0]
         iNode = nodes[interestedNodeID]
-        closestNodes, val, summary = iNode.lookup_for_hash(key=segH)
+        closestNodes, val, summary, _ = iNode.lookup_for_hash(key=segH)
         self.assertEqual(randomSegment, val)
 
-def generateNetwork(k, size, id, errorRate):
-    network = DHTNetwork(id, errorRate)
+    def test_aggregated_delays(self):
+        """ test if the interaction between the nodes in the network actually generate a compounded delay """
+        k = 10
+        size = 500
+        id = 0
+        errorRate = 0  # apply an error rate of 0 (to check if the logic pases)
+        maxDelay = 101
+        minDelay = 10
+        delayRange = range(minDelay, maxDelay, 10)  # ms
+        _, nodes = generateNetwork(k, size, id, errorRate, delayRange)
+        for node in nodes:
+            node.bootstrap()
+
+        randomSegment = "this is a simple segment of code"
+        segH = Hash(randomSegment)
+        # use random node as lookup point
+        publisherNodeID = random.sample(range(1, size), 1)[0]
+        pNode = nodes[publisherNodeID]
+        self.assertNotEqual(pNode.network.len(), 0)
+
+        provideSummary, aggrdelay = pNode.provide_block_segment(randomSegment)
+        self.assertEqual(len(provideSummary["closestNodes"]), k)
+
+        lookupPeers = provideSummary['contactedPeers']
+        providePeers = len(provideSummary['succesNodeIDs'])
+        totdelays = lookupPeers * 2 + providePeers + 2
+        bestDelay = totdelays * minDelay
+        worstDelay = totdelays * maxDelay
+        self.assertGreater(aggrdelay, bestDelay)
+        self.assertLess(aggrdelay, worstDelay)
+
+        interestedNodeID = random.sample(range(1, size), 1)[0]
+        iNode = nodes[interestedNodeID]
+        closestNodes, val, summary, aggrdelay = iNode.lookup_for_hash(key=segH)
+        self.assertEqual(randomSegment, val)
+
+        lookupPeers = summary['successfulCons']
+        totdelays = lookupPeers * 2
+        bestDelay = totdelays * minDelay
+        worstDelay = totdelays * maxDelay
+        self.assertGreater(aggrdelay, bestDelay)
+        self.assertLess(aggrdelay, worstDelay)
+
+def generateNetwork(k, size, id, errorRate, delayRate):
+    network = DHTNetwork(id, errorRate, delayRate)
     nodeIDs = range(1, size+1, 1)
     nodes = []
     for i in nodeIDs:
-        n = DHTClient(nodeid=i, network=network, kbucketSize=k, a=2, b=k, stuckMaxCnt=5)
+        n = DHTClient(nodeid=i, network=network, kbucketSize=k, a=1, b=k, stuckMaxCnt=3)
         network.add_new_node(n)
         nodes.append(n)
     return network, nodes

--- a/tests/test_dht.py
+++ b/tests/test_dht.py
@@ -19,7 +19,7 @@ class TestNetwork(unittest.TestCase):
         k = 20
         size = 200
         id = 0
-        errorRate = 80
+        errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
         network, _ = generateNetwork(k, size, id, errorRate)
         
         # check total size of the network
@@ -47,7 +47,7 @@ class TestNetwork(unittest.TestCase):
         """ test that the routing tables for each nodeID are correctly initialized """
         k = 2
         size = 20
-        errorRate = 80
+        errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
         network, nodes = generateNetwork(k, size, 0, errorRate)
 
         for node in nodes:
@@ -63,7 +63,7 @@ class TestNetwork(unittest.TestCase):
         k = 10
         size = 500 
         id = 0
-        errorRate = 80
+        errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
         _, nodes = generateNetwork(k, size, id, errorRate)
         for node in nodes:
             node.bootstrap()
@@ -97,7 +97,7 @@ class TestNetwork(unittest.TestCase):
         k = 10
         size = 500 
         id = 0
-        errorRate = 80
+        errorRate = 0 # apply an error rate of 0 (to check if the logic pases)
         _, nodes = generateNetwork(k, size, id, errorRate)
         for node in nodes:
             node.bootstrap()


### PR DESCRIPTION
# Motivation
As any other good simulator, the model should represent the real performance of a DHT Network. Thus, this DHT model should have a range of `delays` between connections and data exchange across peers, or `error-rates` which means that the peer rejected the connection or wasn't reachable.

_Related links:_
-- none -- 

# Description
This PR aims to update the current implementation to support connection `error rates` and aggregated delays between the interaction between DHTClients

# Tasks
- [x] add `error_rates` to connections
- [x] make all the DHTClient operations return an aggregated delay between operations
- [x] add any possible test

# Proof of Success 
- [x] are tests happy?


