### PR TITLE
Add/handle neg processes

### DIFF
--- a/dht/dht.py
+++ b/dht/dht.py
@@ -1,6 +1,7 @@
 import os
 import random
 import time
+import multiprocessing
 from concurrent import futures
 from concurrent.futures import ProcessPoolExecutor
 from collections import deque, defaultdict, OrderedDict
@@ -254,6 +255,9 @@ class DHTNetwork:
 
     def init_with_random_peers(self, processes: int, nodesize: int, bsize: int, a: int, b: int, stepstop: int):
         """ optimized way of initializing a network, reducing timings, returns the list of nodes """
+        if processes <= 0:
+            processes = multiprocessing.cpu_count()
+
         # load balancing
         tasks = int(nodesize / processes)
         if nodesize % processes > 0:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
# Motivation
at the moment, the concurrency on the repo is only manageable through the usage of real positive numbers

# Description
this PR adds support of 0 or negative numbers to indicate the usage of all the available cores in the machine

# Tasks
- [ ] translate 0 and negative numbers to `multiprocessing.cpu_count()`

