### PR TITLE
Speeding up lookups

### DIFF
--- a/dht/routing_table.py
+++ b/dht/routing_table.py
@@ -47,11 +47,10 @@ class RoutingTable:
         closestnodes = defaultdict()
         # check the distances for all the nodes in the rt
         for b in self.kbuckets:
-            for n in b.bucketnodes:
-                nH = Hash(n)
-                dist = nH.xor_to_hash(key)
+            for n, nh in b.bucketnodes.items():
+                dist = nh.xor_to_hash(key)
                 closestnodes[n] = dist
-        # sort the dict based on dist 
+        # sort the dict based on dist
         closestnodes = OrderedDict(sorted(closestnodes.items(), key=lambda item: item[1])[:self.bucketsize])
         return closestnodes
 
@@ -81,7 +80,7 @@ class KBucket:
         """ initialize the kbucket with setting a max size along some other control variables """
         self.localnodeid = localnodeid
         self.localnodehash = Hash(localnodeid)
-        self.bucketnodes = deque(maxlen=size)
+        self.bucketnodes = defaultdict(Hash)
         self.bucketsize = size
         self.lastupdated = 0
 
@@ -91,24 +90,22 @@ class KBucket:
         dist = self.localnodehash.xor_to_hash(nodehash)
         bucketdistances = self.get_distances_to_key(self.localnodehash)
         if len(self) >= self.bucketsize:
-            maxval = max(bucketdistances)
-            if maxval < dist:
+            maxDistId = max(bucketdistances.items(), key=lambda localDist: localDist[1])[0]
+            if maxDistId < dist:
                 pass
             else:
-                maxvalid = bucketdistances.index(maxval)
-                del self.bucketnodes[maxvalid]
-                self.bucketnodes.append(nodeid)
+                self.bucketnodes.pop(maxDistId)
+                self.bucketnodes[nodeid] = nodehash
         else:
-            self.bucketnodes.append(nodeid)
+            self.bucketnodes[nodeid] = nodehash
         return self
 
     def get_distances_to_key(self, key: Hash):
         """ return the distances from all the nodes in the bucket to a given key """
-        distances = deque()
-        for nodeid in self.bucketnodes:
-            nodehash = Hash(nodeid)
+        distances = defaultdict(Hash)
+        for nodeid, nodehash in self.bucketnodes.items():
             dist = nodehash.xor_to_hash(key)
-            distances.append(dist)
+            distances[nodeid] = dist
         return distances
 
     def get_bucket_nodes(self):

--- a/dht/routing_table.py
+++ b/dht/routing_table.py
@@ -90,8 +90,8 @@ class KBucket:
         dist = self.localnodehash.xor_to_hash(nodehash)
         bucketdistances = self.get_distances_to_key(self.localnodehash)
         if len(self) >= self.bucketsize:
-            maxDistId = max(bucketdistances.items(), key=lambda localDist: localDist[1])[0]
-            if maxDistId < dist:
+            maxDistId, maxDist = max(bucketdistances.items(), key=lambda localDist: localDist[1])
+            if maxDist < dist:
                 pass
             else:
                 self.bucketnodes.pop(maxDistId)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,4 +1,5 @@
 import unittest
+from collections import OrderedDict
 from dht.routing_table import RoutingTable, KBucket
 from dht.hashes import Hash
 
@@ -22,9 +23,8 @@ class TestDHTHashes(unittest.TestCase):
         zippedogs = sorted(zippedogs, key=lambda pair: pair[1])
         # Second, ensure that the bucket has in fact the closest nodeIDs to the local ID
         distances = kbucket.get_distances_to_key(localhash)
-        ids = kbucket.get_bucket_nodes()
-        zipped_b = sorted(zip(ids, distances), key=lambda pair: pair[1])
-        for idx, pair in enumerate(zipped_b):
+        orderddistances = sorted(distances.items(), key=lambda pair: pair[1])
+        for idx, pair in enumerate(orderddistances):
             self.assertEqual(zippedogs[idx], pair)
 
     def test_routing_table(self):


### PR DESCRIPTION
# Motivation
Despite the current impl works, there were some slowness points raised in regard the lookup simulation time, apparently `6.7 ms` per lookup is too much 🈂️ 
 
# Description
This PR wants to speed up the total duration of the lookup operation. 

# Tasks
- [x] move `bucketnodes` to a dict with {`node_id`: nodehash} -> preventing to redo all the Hashes when getting the distances
- [x] update tables as the `get_distance_to()` now returns a dict with {`node_id`: dist_to_hash} 

# Proof of Success 
Lookups now are done in ~`1.2ms`
```
test done in 371.9404549598694 secs
10_000 nodes, k=20, 262_000 lookups
avg time per lookup: 0.001266827437713856
time to make the 262_000 lookups: 331.9087886810303 secs
```