### PR TITLE
fill new nodes after conn-error with empty dict, not tuple

### DIFF
--- a/dht/dht.py
+++ b/dht/dht.py
@@ -96,7 +96,7 @@ class DHTClient:
 
                 except ConnectionError as e:
                     errortype, errordelay = e.get_delay()
-                    alpha_results.append((errordelay, (), ""))
+                    alpha_results.append((errordelay, {}, ""))
                     alpha_results = deque(sorted(alpha_results, key=lambda pair: pair[0]))
 
                 # check if the concurrency array is full


### PR DESCRIPTION
# Motivation
There was an error when enabling the error rate on the lookup configuration:
```python
study lookup_nn1000_sampl100000_fer0_ser5_fdr50-50_sdr500_k20_a3_b20_steps3 ready
network init done in 3.0734004974365234 secs
Traceback (most recent call last):                                                                                                                                                                                              ]   0%
  File "/home/cortze/devel/codex/das-research/DHT/dhtStudy.py", line 186, in <module>
    study(config)
  File "/home/cortze/devel/codex/das-research/DHT/dhtStudy.py", line 169, in study
    singleStudy.run()
  File "/home/cortze/devel/codex/das-research/DHT/dhtStudy.py", line 91, in run
    closest, _, summary, aggrDelay = builderNode.lookup_for_hash(sh)
  File "/home/cortze/devel/codex/das-research/py-dht/dht/dht.py", line 121, in lookup_for_hash
    if has_closer_nodes(closestnodes, mindelayedlookup[1]):
  File "/home/cortze/devel/codex/das-research/py-dht/dht/dht.py", line 55, in has_closer_nodes
    for n, dist in new.items():
AttributeError: 'tuple' object has no attribute 'items'
```

_Related links:_
- #14  

# Description
This PR fixes the error

# Tasks
- [x] Fix error

# Proof of Success 
- [x] Test pass