### PR TITLE
Make lookup accuracy optional

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -327,7 +327,7 @@ class TestNetwork(unittest.TestCase):
         rnode = n.nodestore.get_node(randomid)
         self.assertNotEqual(rnode.network.len(), 0)
 
-        closestnodes, val, summary, _ = rnode.lookup_for_hash(key=segH)
+        closestnodes, val, summary, _ = rnode.lookup_for_hash(key=segH, trackaccuracy=True)
         self.assertEqual(val, "")  # empty val, nothing stored yet
         self.assertEqual(len(closestnodes), k)
         self.assertGreater(summary['accuracy'], targetaccuracy)


### PR DESCRIPTION
# Motivation
Adding the accuracy metric to the lookup makes the lookup 5-6 times slower, which means that the lookup experiments with 100k samples, 20k nodes, and k=20 go from 5-6 mins to finish to 30+
 
# Description
The PR makes the accuracy metric optional, returning an "unknown" field in the summary if it wasn't set.

# Tasks
- [x]  Add accuracy tracking as a separate option to the lookup

# Proof of Success 
happy tests
