### PR TITLE
Enable end of the lookup if value is found

### DIFF
--- a/dht/dht.py
+++ b/dht/dht.py
@@ -39,7 +39,7 @@ class DHTClient:
         # Return the summary of the RoutingTable
         return self.rt.summary()
 
-    def lookup_for_hash(self, key: Hash, trackaccuracy: bool = False):
+    def lookup_for_hash(self, key: Hash, trackaccuracy: bool = False, finishwithfirstvalue: bool = True):
         """ search for the closest peers to any given key, starting the lookup for the closest nodes in 
         the local routing table, and contacting Alpha nodes in parallel """
         lookupsummary = {
@@ -73,8 +73,10 @@ class DHTClient:
         stepscnt = 0
 
         while (stepscnt < self.lookupsteptostop) and (len(nodestotry) > 0):
-            nodes = nodestotry.copy()
+            if finishwithfirstvalue and lookupvalue != "":
+                break
 
+            nodes = nodestotry.copy()
             for node in nodes:
                 nodestotry.pop(node)  # remove item from peers to attempt
                 if node in triednodes:  # make sure we don't contact the same node twice
@@ -174,7 +176,7 @@ class DHTClient:
             'aggrDelay': 0,
         }
         segH = Hash(segment)
-        closestnodes, _, lookupsummary, lookupdelay = self.lookup_for_hash(segH)
+        closestnodes, _, lookupsummary, lookupdelay = self.lookup_for_hash(segH, finishwithfirstvalue=False)
         providesummary['aggrDelay'] += lookupdelay
         for cn in closestnodes:
             try:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -104,7 +104,7 @@ class TestNetwork(unittest.TestCase):
         randomid = random.sample(range(1, size), 1)[0]
         rnode = network.nodestore.get_node(randomid)
 
-        closestnodes, _, _, _ = rnode.lookup_for_hash(segH)
+        closestnodes, _, _, _ = rnode.lookup_for_hash(segH, finishwithfirstvalue=False)
         network_closest = network.get_closest_nodes_to_hash(segH, b)
         for nodeid, _ in network_closest:
             self.assertEqual(nodeid in closestnodes, True)
@@ -529,7 +529,7 @@ class TestNetwork(unittest.TestCase):
         segH = Hash(randomSegment)
         interestednodeid = random.sample(range(1, size), 1)[0]
         inode = n.nodestore.get_node(interestednodeid)
-        closestnodes, _, summary, aggrdelay = inode.lookup_for_hash(segH)
+        closestnodes, _, summary, aggrdelay = inode.lookup_for_hash(segH, finishwithfirstvalue=False)
         self.assertEqual(len(closestnodes), k)
         rounds = int(summary['connectionFinished'] / alpha)
         if (summary['connectionFinished'] % alpha) > 0:


### PR DESCRIPTION
# Motivation
As the `lookup` function is used to get i) the closest peers to a hash, and ii) find a given value, there is a need to define whether the lookup should keep looking up if the value for the given hash is found. 
  
# Description
This PR modifies the `lookup` method call enabling it to `break on value` or not (break on k closest nodes)

# Tasks
- [ ] Add a boolean flag that enables or disables the  `finishonfirstvalue

# Proof of Success 
- test happy
