### PR TITLE
Split delay for connections from Fast error ones

### DIFF
--- a/benchmarks/hashes.py
+++ b/benchmarks/hashes.py
@@ -133,6 +133,7 @@ if __name__ == "__main__":
     args.add_argument('-i')  # number of iterations (for statistical robustness)
     args.add_argument('-k')  # bucket size
     args.add_argument('-n')  # network size (to compose the rt)
+    args.add_argument('--threads')  # network size (to compose the rt)s
     a = args.parse_args()
     main(a)
 

--- a/benchmarks/network.py
+++ b/benchmarks/network.py
@@ -54,7 +54,7 @@ def main(args):
 
 def gen_network(k: int, network_size: int):
     node_ids = random.sample(range(network_size), network_size)
-    network = DHTNetwork(networkid=0, errorrate=0, delayrange=None)
+    network = DHTNetwork(networkid=0)
     for node in node_ids:
         node = DHTClient(node, network, k, a=3, b=k, steptostop=5)
         network.add_new_node(node)
@@ -136,9 +136,7 @@ def dht_network_fast_bootstrap(tag_base: str, i: int, k: int, network_size: int)
 
     def task() -> float:
         # init
-        errorrate = 0
-        delayrange = None
-        network = DHTNetwork(0, errorrate, delayrange)
+        network = DHTNetwork(networkid=0)
 
         # measurement
         start = time.time()
@@ -159,9 +157,7 @@ def dht_network_fast_threaded_bootstrap(tag_base: str, threads:int, i: int, k: i
 
     def task() -> float:
         # init
-        errorrate = 0
-        delayrange = None
-        network = DHTNetwork(0, errorrate, delayrange)
+        network = DHTNetwork(networkid=0)
 
         # measurement
         start = time.time()

--- a/benchmarks/routing.py
+++ b/benchmarks/routing.py
@@ -128,6 +128,7 @@ if __name__ == "__main__":
     args.add_argument('-i')  # number of iterations (for statistical robustness)
     args.add_argument('-k')  # bucket size
     args.add_argument('-n')  # network size (to compose the rt)
+    args.add_argument('--threads')  # network size (to compose the rt)
     a = args.parse_args()
     main(a)
 

--- a/dht/dht.py
+++ b/dht/dht.py
@@ -287,11 +287,12 @@ class DHTNetwork:
     """ serves a the shared point between all the nodes participating in the simulation,
     allows node to communicat with eachother without needing to implement an API or similar"""
 
-    def __init__(self, networkid: int, fasterrorrate: int, slowerrorrate: int, fastdelayrange, slowdelay):
+    def __init__(self, networkid: int, fasterrorrate: int=0, slowerrorrate: int=0, conndelayrange = None, fastdelayrange = None, slowdelay = None):
         """ class initializer, it allows to define the networkID and the delays between nodes """
         self.networkid = networkid
         self.fasterrorrate = fasterrorrate  # %
         self.slowerrorrate = slowerrorrate  # %
+        self.conndelatrange = conndelayrange
         self.fastdelayrange = fastdelayrange  # list() in ms -> i.e., (5, 100) ms | None
         self.slowdelay = slowdelay  # timeot delay
         self.nodestore = NodeStore()
@@ -386,7 +387,7 @@ class DHTNetwork:
                 connerror = ConnectionError(targetnode, "slow error", time.time(), self.slowdelay)
                 self.errortracker.append(connerror)
                 raise connerror
-            connection = Connection(self.connectioncnt, ognode, self.nodestore.get_node(targetnode), self.fastdelayrange)
+            connection = Connection(self.connectioncnt, ognode, self.nodestore.get_node(targetnode), self.conndelatrange)
             self.connectiontracker.append({
                 'time': time.time(),
                 'from': ognode,

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -16,6 +16,7 @@ class TestNetwork(unittest.TestCase):
         id = 0
         fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
         slowerrorrate = 0
+        conndelayrange = None
         fastdelayrange = None  # ms
         slowdelayrange = None
         network, _ = generate_network(
@@ -24,6 +25,7 @@ class TestNetwork(unittest.TestCase):
             id,
             fasterrorrate,
             slowerrorrate,
+            conndelayrange,
             fastdelayrange,
             slowdelayrange)
         
@@ -56,16 +58,7 @@ class TestNetwork(unittest.TestCase):
         nodeid = 1
         steps4stop = 3
         size = 100
-        fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
-        slowerrorrate = 0
-        fastdelayrange = None  # ms
-        slowdelayrange = None
-        network = DHTNetwork(
-            nodeid,
-            fasterrorrate,
-            slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
+        network = DHTNetwork(networkid=0)
         classicnode = DHTClient(nodeid, network, k, a, b, steps4stop)
         fastnode = DHTClient(nodeid, network, k, a, b, steps4stop)
 
@@ -81,23 +74,12 @@ class TestNetwork(unittest.TestCase):
     def test_networks_closest_peers_to_hash(self):
         """ test the routing table of a dht cli using the fast approach """
         k = 5
-        a = 1
+        a = 3
         b = k
-        nodeid = 1
         steps4stop = 3
         size = 1000
-        fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
-        slowerrorrate = 0
-        fastdelayrange = None  # ms
-        slowdelayrange = None
-        network = DHTNetwork(
-            nodeid,
-            fasterrorrate,
-            slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
-
-        nodes = network.init_with_random_peers(1, size, k, 3, k, 3)
+        network = DHTNetwork(networkid=0)
+        _ = network.init_with_random_peers(1, size, k, a, k, steps4stop)
 
         randomsegment = "this is a simple segment of code"
         segH = Hash(randomsegment)
@@ -116,16 +98,7 @@ class TestNetwork(unittest.TestCase):
         b = k
         step4stop = 3
         size = 1000
-        fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
-        slowerrorrate = 0
-        fastdelayrange = None  # ms
-        slowdelayrange = None
-        network = DHTNetwork(
-            0,
-            fasterrorrate,
-            slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
+        network = DHTNetwork(networkid=0)
         network.init_with_random_peers(1, size, k, a, b, step4stop)
 
         for nodeid in range(size):
@@ -147,16 +120,7 @@ class TestNetwork(unittest.TestCase):
         step4stop = 3
         size = 1000
         threads = 2
-        fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
-        slowerrorrate = 0
-        fastdelayrange = None  # ms
-        slowdelayrange = None
-        network = DHTNetwork(
-            0,
-            fasterrorrate,
-            slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
+        network = DHTNetwork(networkid=0)
         network.init_with_random_peers(threads, size, k, a, b, step4stop)
 
         for nodeid in range(size):
@@ -178,16 +142,7 @@ class TestNetwork(unittest.TestCase):
         step4stop = 3
         size = 1000
         threads = 4
-        fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
-        slowerrorrate = 0
-        fastdelayrange = None  # ms
-        slowdelayrange = None
-        network = DHTNetwork(
-            0,
-            fasterrorrate,
-            slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
+        network = DHTNetwork(networkid=0)
         start = time.time()
         _ = network.init_with_random_peers(threads, size, k, a, b, step4stop)
         print(f'{size} nodes in {time.time() - start} - {threads} cores')
@@ -198,6 +153,7 @@ class TestNetwork(unittest.TestCase):
         size = 200
         fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
         slowerrorrate = 0
+        conndalayrange = None
         fastdelayrange = None  # ms
         slowdelayrange = None
         network, nodes = generate_network(
@@ -206,6 +162,7 @@ class TestNetwork(unittest.TestCase):
             id,
             fasterrorrate,
             slowerrorrate,
+            conndalayrange,
             fastdelayrange,
             slowdelayrange)
 
@@ -224,6 +181,7 @@ class TestNetwork(unittest.TestCase):
         id = 0
         fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
         slowerrorrate = 0
+        conndelayrange = None
         fastdelayrange = None  # ms
         slowdelayrange = None
         _, nodes = generate_network(
@@ -232,6 +190,7 @@ class TestNetwork(unittest.TestCase):
             id,
             fasterrorrate,
             slowerrorrate,
+            conndelayrange,
             fastdelayrange,
             slowdelayrange)
 
@@ -264,19 +223,13 @@ class TestNetwork(unittest.TestCase):
     def test_dht_interop_with_alpha(self):
         """ test if the nodes in the network actually route to the closest peer, and implicidly, if the DHTclient interface works """
         k = 10
+        a = 3
+        b = k
+        steps4stop = 3
         size = 500
         netid = 0
-        fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
-        slowerrorrate = 0
-        fastdelayrange = None  # ms
-        slowdelayrange = None
-        n = DHTNetwork(
-            netid,
-            fasterrorrate,
-            slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
-        nodes = n.init_with_random_peers(1, size, k, 3, k, 3)
+        n = DHTNetwork(networkid=netid)
+        nodes = n.init_with_random_peers(1, size, k, a, b, steps4stop)
 
         randomsegment = "this is a simple segment of code"
         segH = Hash(randomsegment)
@@ -310,15 +263,17 @@ class TestNetwork(unittest.TestCase):
         targetaccuracy = 70  # %
         fasterrorrate = 25  # apply an error rate of 0 (to check if the logic pases)
         slowerrorrate = 0
+        conndelayrange = [30, 30]  # ms
         fastdelayrange = [30, 30]  # ms
         slowdelayrange = None
         n = DHTNetwork(
             netid,
             fasterrorrate,
             slowerrorrate,
+            conndelayrange,
             fastdelayrange,
             slowdelayrange)
-        nodes = n.init_with_random_peers(1, size, k, 3, k, 3)
+        n.init_with_random_peers(1, size, k, 3, k, 3)
 
         randomsegment = "this is a simple segment of code"
         segH = Hash(randomsegment)
@@ -336,20 +291,14 @@ class TestNetwork(unittest.TestCase):
     def test_dht_interop_with_fast_init(self):
         """ test if the nodes in the network actually route to the closest peer, and implicidly, if the DHTclient interface works """
         k = 10
+        a = 1
+        b = k
+        steps4stop = 3
         size = 500
-        i = 0
+        netid = 0
         jobs = 4
-        fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
-        slowerrorrate = 0
-        fastdelayrange = None  # ms
-        slowdelayrange = None
-        n = DHTNetwork(
-            i,
-            fasterrorrate,
-            slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
-        _ = n.init_with_random_peers(jobs, size, k, 1, k, 3)
+        n = DHTNetwork(networkid=netid)
+        n.init_with_random_peers(jobs, size, k, a, b, steps4stop)
 
         randomsegment = "this is a simple segment of code"
         segH = Hash(randomsegment)
@@ -381,6 +330,7 @@ class TestNetwork(unittest.TestCase):
         id = 0
         fasterrorrate = 20  # apply an error rate of 0 (to check if the logic pases)
         slowerrorrate = 0
+        conndelayrange = None
         fastdelayrange = None  # ms
         slowdelayrange = None
         network, nodes = generate_network(
@@ -389,6 +339,7 @@ class TestNetwork(unittest.TestCase):
             id,
             fasterrorrate,
             slowerrorrate,
+            conndelayrange,
             fastdelayrange,
             slowdelayrange)
         for node in nodes:
@@ -417,6 +368,7 @@ class TestNetwork(unittest.TestCase):
         id = 0
         fasterrorrate = 0  # apply an error rate of 0 (to check if the logic pases)
         slowerrorrate = 0
+        conndelayrange = None
         fastdelayrange = None  # ms
         slowdelayrange = None
         _, nodes = generate_network(
@@ -425,6 +377,7 @@ class TestNetwork(unittest.TestCase):
             id,
             fasterrorrate,
             slowerrorrate,
+            conndelayrange,
             fastdelayrange,
             slowdelayrange)
         for node in nodes:
@@ -455,9 +408,10 @@ class TestNetwork(unittest.TestCase):
         slowerrorrate = 0
         maxDelay = 101
         minDelay = 10
-
         delayrange = range(minDelay, maxDelay, 10)  # ms
-        slowdelay = None
+        fasterrordelayrange = None
+        slowerrordelayrange = None
+
         _, nodes = generate_network(
             k,
             size,
@@ -465,7 +419,8 @@ class TestNetwork(unittest.TestCase):
             fasterrorrate,
             slowerrorrate,
             delayrange,
-            slowdelay)
+            fasterrordelayrange,
+            slowerrordelayrange)
         for node in nodes:
             node.bootstrap()
 
@@ -512,11 +467,12 @@ class TestNetwork(unittest.TestCase):
         slowerrorrate = 0
 
         delay = 50  # ms
+        conndelayrange = [delay, delay]  # ms
         fastdelayrange = [delay, delay]  # ms
         slowdelayrate = None
 
         # init the network
-        n = DHTNetwork(i, fasterrorrate, slowerrorrate, fastdelayrange, slowdelayrate)
+        n = DHTNetwork(i, fasterrorrate, slowerrorrate, conndelayrange, fastdelayrange, slowdelayrate)
         _ = n.init_with_random_peers(jobs, size, k, alpha, beta, stepstostop)
 
         # use random node as lookup point
@@ -537,13 +493,14 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(aggrdelay, rounds * (delay*2))
 
 
-def generate_network(k, size, netid, fasterrorrate, slowerrorrate, fastdelayrange, slowdelayrange):
+def generate_network(k, size, netid, fasterrorrate, slowerrorrate, conndalayrange, fasterrordelayrange, slowerrordelayrange):
     network = DHTNetwork(
             netid,
             fasterrorrate,
             slowerrorrate,
-            fastdelayrange,
-            slowdelayrange)
+            conndalayrange,
+            fasterrordelayrange,
+            slowerrordelayrange)
     nodeids = range(0, size, 1)
     nodes = []
     for i in nodeids:


### PR DESCRIPTION
# Motivation
Although most of the times, the connection delay will be equal to the fast error connection, it is nice to have them as separated arguments for the network model

 
# Description
this PR makes the split between both arguments so that the network has:
- Connection delay range
- Fast error delay range
- Slow error delay range

# Tasks
- [x] Add new argument to the Network model
- [x] Fix tests
- [x] Fix benchmarks

# Proof of Success 
- Test happy
- TODO: the network benchmark (the launcher) still needs to add the jobs parameter for the network init
